### PR TITLE
Add activeTextColor to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,12 @@ export interface SegmentedControlIOSProps extends ViewProps {
 
   /**
    * (iOS 13 only)
+   * Text color of the active control.
+   */
+  activeTextColor?: string;
+
+  /**
+   * (iOS 13 only)
    * Background color of the control.
    */
   backgroundColor?: string;


### PR DESCRIPTION
# Overview
There's no type information for `activeTextColor` property which was added recently in https://github.com/react-native-community/segmented-control/pull/50
<img width="751" alt="Screenshot 2020-03-12 at 13 21 57" src="https://user-images.githubusercontent.com/589627/76525832-82ab6800-6464-11ea-8f77-125cbbcd1549.png"> 

# Test Plan
I don't really have a test plan for this fix. For now it simply works.