### PR TITLE
fix: ios: Not selected tab gets bold face when setting fontSize #80

### DIFF
--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -41,10 +41,14 @@
 
 - (void)setFontSize:(NSInteger)fontSize
 {
-  UIFont *font = [UIFont boldSystemFontOfSize: fontSize];
+  UIFont *font = [UIFont systemFontOfSize: fontSize];
     [_attributes setObject: font forKey:NSFontAttributeName];
     [self setTitleTextAttributes:_attributes
                                 forState:UIControlStateNormal];
+  UIFont *fontBold = [UIFont boldSystemFontOfSize: fontSize];
+    [_attributes setObject: fontBold forKey:NSFontAttributeName];
+    [self setTitleTextAttributes:_attributes
+                                forState:UIControlStateSelected];
 }
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor

--- a/js/SegmentedControlTab.js
+++ b/js/SegmentedControlTab.js
@@ -42,22 +42,12 @@ export const SegmentedControlTab = ({
   };
   const color = getColor();
 
-  const getBackgroundColor = () => {
-    if (selected && tintColor) {
-      return tintColor;
-    }
-    return 'white';
-  };
   return (
     <TouchableOpacity
       style={styles.container}
       disabled={!enabled}
       onPress={onSelect}>
-      <View
-        style={[
-          styles.default,
-          selected && {backgroundColor: getBackgroundColor()},
-        ]}>
+      <View style={[styles.default]}>
         <Text
           style={[
             {color},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/segmented-control",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "React Native SegmentedControlIOS library",
   "main": "js/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Fixing issue #80 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Add `fontSize` to the segmented control and check that boldface is applied only to the selected tab.