### PR TITLE
fix: allow combining attributes

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -78,10 +78,20 @@ export default class App extends React.Component<{}, $FlowFixMeState> {
           <Text style={styles.text}>
             Segmented controls can have defined fontSize
           </Text>
+          <View style={styles.segmentContainer}>
+            <SegmentedControl
+              values={['One', 'Two']}
+              style={{height: 80}}
+              fontSize={32}
+            />
+          </View>
           <SegmentedControl
             values={['One', 'Two']}
             style={{height: 80}}
             fontSize={32}
+            textColor="blue"
+            tintColor="green"
+            activeTextColor="red"
           />
         </View>
         <View>

--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -78,7 +78,8 @@
     #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
         __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     if (@available(iOS 13.0, *)) {
-      [self setTitleTextAttributes:@{NSForegroundColorAttributeName: textColor}
+      [_attributes setObject: textColor forKey:NSForegroundColorAttributeName];
+      [self setTitleTextAttributes:_attributes
                   forState:UIControlStateSelected];
     }
     #endif
@@ -91,8 +92,9 @@
     __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
   if (@available(iOS 13.0, *)) {
     [self setSelectedSegmentTintColor:tintColor];
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: tintColor}
-                         forState:UIControlStateNormal];
+    [_attributes setObject: tintColor forKey:NSForegroundColorAttributeName];
+    [self setTitleTextAttributes:_attributes
+                  forState:UIControlStateNormal];
   }
 #endif
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
combining fontSize, textColor, tintColor and activeTextColor lead to some styles not working.
This PR fixes the problem

# Test Plan
Tested on iPhone Simulator
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
