### PR TITLE
[iOS] fix activeFontStyle prop being override by fontStyle

### DIFF
--- a/ios/RNCSegmentedControlManager.m
+++ b/ios/RNCSegmentedControlManager.m
@@ -38,25 +38,18 @@ RCT_CUSTOM_VIEW_PROPERTY(fontStyle, NSObject, RNCSegmentedControl) {
       NSInteger fontSize =
           json[@"fontSize"] ? [RCTConvert NSInteger:json[@"fontSize"]] : 13.0;
       UIFont *font = [UIFont systemFontOfSize:fontSize];
-      UIFont *activeFont = [UIFont boldSystemFontOfSize:fontSize];
       if (json[@"fontFamily"]) {
         UIFont *tempFont = [UIFont fontWithName:json[@"fontFamily"]
                                            size:fontSize];
         if (tempFont != nil) {
           font = tempFont;
-          activeFont = tempFont;
         }
       }
 
       NSDictionary *attributes = [NSDictionary
           dictionaryWithObjectsAndKeys:font, NSFontAttributeName, color,
                                        NSForegroundColorAttributeName, nil];
-      NSDictionary *activeAttributes = [NSDictionary
-          dictionaryWithObjectsAndKeys:activeFont, NSFontAttributeName, color,
-                                       NSForegroundColorAttributeName, nil];
       [view setTitleTextAttributes:attributes forState:UIControlStateNormal];
-      [view setTitleTextAttributes:activeAttributes
-                          forState:UIControlStateSelected];
     }
   }
 #endif


### PR DESCRIPTION
# Overview

Fixes: https://github.com/react-native-community/segmented-control/issues/93

# Test Plan

Use example with `fontStyle` and `activeFontStyle`