### PR TITLE
Fix Animation Active segmant width in RTL

### DIFF
--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as React from 'react';
-import {Animated,I18nManager, Easing, StyleSheet, View} from 'react-native';
+import {Animated, I18nManager, Easing, StyleSheet, View} from 'react-native';
 import {SegmentedControlTab} from './SegmentedControlTab';
 
 import type {SegmentedControlProps} from './types';

--- a/js/SegmentedControl.js
+++ b/js/SegmentedControl.js
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as React from 'react';
-import {Animated, Easing, StyleSheet, View} from 'react-native';
+import {Animated,I18nManager, Easing, StyleSheet, View} from 'react-native';
 import {SegmentedControlTab} from './SegmentedControlTab';
 
 import type {SegmentedControlProps} from './types';
@@ -43,8 +43,9 @@ const SegmentedControl = ({
 
   React.useEffect(() => {
     if (animation && segmentWidth) {
+      let isRTL = I18nManager.isRTL ? -segmentWidth : segmentWidth;
       Animated.timing(animation, {
-        toValue: segmentWidth * (selectedIndex || 0),
+        toValue: isRTL * (selectedIndex || 0),
         duration: 300,
         easing: Easing.out(Easing.quad),
         useNativeDriver: true,


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
I have a Fully RTL App when I press to next segment the Animation It goes the other way around



# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
I import I18nManager then defined a variable to check if the app RTL or not and based on it, I change `segmentWidth` to negative if true, else i return `segmentWidth` 

**Before**
![Screen-Recording-2020-09-02-at-5](https://user-images.githubusercontent.com/24620979/91994753-a37fb680-ed3f-11ea-91a5-d2c3337f28eb.gif)

**After**

![Screen-Recording-2020-09-02-at-6](https://user-images.githubusercontent.com/24620979/91994942-dcb82680-ed3f-11ea-93a4-7168b39b981f.gif)

