### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-segmented-control.podspec
+++ b/react-native-segmented-control.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-native-community/react-native-segmented-control.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
# Overview
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for native modules on iOS. This change requires to React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116


# Test Plan
Use this branch to install with an app running on Xcode 12.
